### PR TITLE
Update examples to match latest Kafka trunk (as of commit 1a539c7, Feb 08)

### DIFF
--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <java.version>1.8</java.version>
         <kafka.version>0.9.1.0-SNAPSHOT</kafka.version>
-        <kafka.scala.version>2.10</kafka.scala.version>
+        <kafka.scala.version>2.11</kafka.scala.version>
         <scala.version>${kafka.scala.version}.6</scala.version>
         <confluent.version>2.0.0-SNAPSHOT</confluent.version>
         <avro.version>1.7.7</avro.version>
@@ -146,16 +146,14 @@
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.2.1</version>
                 <configuration>
-                    <!--
-                        Override the Scala version to be used.
-                        Normally, the plugin would automatically pick the version defined via the
-                        'org.scala-lang:scala-library' dependency above, but that dependency must
-                        be either 2.10 or 2.11 because Kafka is not yet built against 2.12.
-                    -->
-
-                              <groupId>org.scala-lang</groupId>
-                                          <artifactId>scala-library</artifactId>
-                    <scalaVersion>2.12.0-M3</scalaVersion>
+                    <args>
+                        <!--
+                           In combination with Scala 2.11, `-Xexperimental` enables SAM
+                           for Java 8 lambda support.  Make sure `kafka.scala.version`
+                           is set to `2.11`, not `2.10`.
+                        -->
+                        <arg>-Xexperimental</arg>
+                    </args>
                 </configuration>
                 <executions>
                     <execution>

--- a/streams/pom.xml
+++ b/streams/pom.xml
@@ -157,6 +157,14 @@
                                           <artifactId>scala-library</artifactId>
                     <scalaVersion>2.12.0-M3</scalaVersion>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/streams/src/main/java/io/confluent/examples/streams/MapFunctionExample.java
+++ b/streams/src/main/java/io/confluent/examples/streams/MapFunctionExample.java
@@ -19,11 +19,11 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreaming;
-import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
-import org.apache.kafka.streams.kstream.KeyValue;
 
 import java.util.Properties;
 
@@ -79,16 +79,16 @@ public class MapFunctionExample {
     originalAndUppercased.to("OriginalAndUppercased", new StringSerializer(), new StringSerializer());
 
     Properties streamingConfiguration = new Properties();
-    streamingConfiguration.put(StreamingConfig.JOB_ID_CONFIG, "map-function-example");
-    streamingConfiguration.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-    streamingConfiguration.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    streamingConfiguration.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    streamingConfiguration.put(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    streamingConfiguration.put(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    streamingConfiguration.put(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, SystemTimestampExtractor.class);
+    streamingConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "map-function-example");
+    streamingConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    streamingConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+    streamingConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    streamingConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+    streamingConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    streamingConfiguration.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, SystemTimestampExtractor.class);
 
-    KafkaStreaming stream = new KafkaStreaming(builder, new StreamingConfig(streamingConfiguration));
-    stream.start();
+    KafkaStreams streams = new KafkaStreams(builder, streamingConfiguration);
+    streams.start();
   }
 
 }

--- a/streams/src/main/java/io/confluent/examples/streams/TopArticlesExample.java
+++ b/streams/src/main/java/io/confluent/examples/streams/TopArticlesExample.java
@@ -64,7 +64,7 @@ public class TopArticlesExample {
 
     public static void main(String[] args) throws Exception {
         Properties streamsConfiguration = new Properties();
-        streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "anomalydetection-example");
+        streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "top-articles-example");
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         streamsConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, GenericAvroSerializer.class);

--- a/streams/src/main/java/io/confluent/examples/streams/TopArticlesExample.java
+++ b/streams/src/main/java/io/confluent/examples/streams/TopArticlesExample.java
@@ -19,20 +19,23 @@ import io.confluent.examples.streams.utils.CollectionDeserializer;
 import io.confluent.examples.streams.utils.CollectionSerializer;
 import io.confluent.examples.streams.utils.GenericAvroDeserializer;
 import io.confluent.examples.streams.utils.GenericAvroSerializer;
-import io.confluent.examples.streams.utils.SystemTimestampExtractor;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreaming;
-import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.HoppingWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.kstream.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.WindowedDeserializer;
 import org.apache.kafka.streams.kstream.internals.WindowedSerializer;
@@ -60,19 +63,20 @@ public class TopArticlesExample {
     }
 
     public static void main(String[] args) throws Exception {
-        Properties props = new Properties();
-        props.put(StreamingConfig.JOB_ID_CONFIG, "anomalydetection-example");
-        props.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        props.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        props.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, GenericAvroSerializer.class);
-        props.put(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, GenericAvroDeserializer.class);
-        props.put(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, SystemTimestampExtractor.class);
+        Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "anomalydetection-example");
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        streamsConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, GenericAvroSerializer.class);
+        streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, GenericAvroDeserializer.class);
 
-        StringSerializer stringSerializer = new StringSerializer();
-        StringDeserializer stringDeserializer = new StringDeserializer();
-
-        StreamingConfig config = new StreamingConfig(props);
+        final StringSerializer stringSerializer = new StringSerializer();
+        final StringDeserializer stringDeserializer = new StringDeserializer();
+        final Serializer<Long> longSerializer = new LongSerializer();
+        final Deserializer<Long> longDeserializer = new LongDeserializer();
+        final Serializer<GenericRecord> avroSerializer = new GenericAvroSerializer();
+        final Deserializer<GenericRecord> avroDeserializer = new GenericAvroDeserializer();
 
         KStreamBuilder builder = new KStreamBuilder();
 
@@ -88,90 +92,82 @@ public class TopArticlesExample {
 
         KTable<Windowed<GenericRecord>, Long> viewCounts = articleViews
                 // count the clicks within one week
-                .countByKey(HoppingWindows.of("PageViewCountWindows").with(7 * 24 * 60 * 60 * 1000), null, null);
+                .countByKey(HoppingWindows.of("PageViewCountWindows").with(7 * 24 * 60 * 60 * 1000),
+                    avroSerializer, longSerializer, avroDeserializer, longDeserializer);
 
-         KTable<Windowed<String>, Collection<GenericRecord>> topViewCounts = viewCounts
-                .aggregate(() -> new Aggregator<Windowed<String>, GenericRecord, Collection<GenericRecord>>() {
-                             private final int k = 100;
+        int topN = 100;
+        KTable<Windowed<String>, Collection<GenericRecord>> topViewCounts = viewCounts
+                .aggregate(
+                     // initial value
+                     Collections::<GenericRecord>emptySet,
+                     // the "add" aggregator
+                     new Aggregator<Windowed<String>, GenericRecord, Collection<GenericRecord>>() {
 
-                             private final Map<Windowed<String>, PriorityQueue<GenericRecord>> sorted = new HashMap<>();
+                         private final Map<Windowed<String>, PriorityQueue<GenericRecord>> sorted = new HashMap<>();
 
-                             @Override
-                             public Collection<GenericRecord> initialValue() {
-                                 return Collections.<GenericRecord>emptySet();
+                         @Override
+                         public Collection<GenericRecord> apply(Windowed<String> aggKey, GenericRecord value, Collection<GenericRecord> aggregate) {
+                             PriorityQueue<GenericRecord> queue = sorted.get(aggKey);
+
+                             if (queue == null) {
+                                 queue = new PriorityQueue<>();
+                                 sorted.put(aggKey, queue);
                              }
+                             queue.add(value);
 
-                             @Override
-                             public Collection<GenericRecord> add(Windowed<String> aggKey, GenericRecord value, Collection<GenericRecord> aggregate) {
-                                 PriorityQueue<GenericRecord> queue = sorted.get(aggKey);
-                                 if (queue == null) {
-                                     queue = new PriorityQueue<>();
-                                     sorted.put(aggKey, queue);
-                                 }
-
-                                 queue.add(value);
-
-                                 PriorityQueue<GenericRecord> copy = new PriorityQueue<>(queue);
-
-                                 Set<GenericRecord> ret = new HashSet<>();
-                                 for (int i = 1; i <= k; i++)
-                                     ret.add(copy.poll());
-
-                                 return ret;
+                             PriorityQueue<GenericRecord> copy = new PriorityQueue<>(queue);
+                             Set<GenericRecord> ret = new HashSet<>();
+                             for (int i = 1; i <= topN; i++) {
+                                 ret.add(copy.poll());
                              }
+                            return ret;
+                         }
+                     },
+                     // the "remove" aggregator
+                     new Aggregator<Windowed<String>, GenericRecord, Collection<GenericRecord>>() {
 
-                             @Override
-                             public Collection<GenericRecord> remove(Windowed<String> aggKey, GenericRecord value, Collection<GenericRecord> aggregate) {
-                                 PriorityQueue<GenericRecord> queue = sorted.get(aggKey);
+                       // FIXME: `sorted` must be shared between the `add` (above) and the `remove` (= this) aggregator
+                       private final Map<Windowed<String>, PriorityQueue<GenericRecord>> sorted = new HashMap<>();
 
-                                 if (queue == null)
-                                     throw new IllegalStateException("This should not happen.");
+                       @Override
+                       public Collection<GenericRecord> apply(Windowed<String> aggKey, GenericRecord value, Collection<GenericRecord> aggregate) {
+                           PriorityQueue<GenericRecord> queue = sorted.get(aggKey);
 
-                                 queue.remove(value);
+                           if (queue == null) {
+                              throw new IllegalStateException("This should not happen.");
+                           }
+                           queue.remove(value);
 
-                                 PriorityQueue<GenericRecord> copy = new PriorityQueue<>(queue);
-
-                                 Set<GenericRecord> ret = new HashSet<>();
-                                 for (int i = 1; i <= k; i++)
-                                     ret.add(copy.poll());
-
-                                 return ret;
-                             }
-
-                             @Override
-                             public Collection<GenericRecord> merge(Collection<GenericRecord> aggr1, Collection<GenericRecord> aggr2) {
-                                 PriorityQueue<GenericRecord> copy = new PriorityQueue<>(aggr1);
-                                 copy.addAll(aggr2);
-
-                                 Set<GenericRecord> ret = new HashSet<>();
-                                 for (int i = 1; i <= k; i++)
-                                     ret.add(copy.poll());
-
-                                 return ret;
-                             }
-                         },
-                         (windowedArticle, count) -> {
-                             // project on the industry field for key
-                             Windowed<String> windowedIndustry = new Windowed<>((String) windowedArticle.value().get("industry"), windowedArticle.window());
-
-                             // add the page into the value
-                             GenericRecord viewStats = new GenericData.Record(schema);
-                             viewStats.put("page", "pageId");
-                             viewStats.put("industry", "industryName");
-                             viewStats.put("count", count);
-
-                             return new KeyValue<>(windowedIndustry, viewStats);
-                         },
-                         new WindowedSerializer<>(stringSerializer),
-                         null,
-                         new CollectionSerializer<>(),
-                         new WindowedDeserializer<>(stringDeserializer),
-                         null,
-                         new CollectionDeserializer<>(), "Top100Articles");
+                           PriorityQueue<GenericRecord> copy = new PriorityQueue<>(queue);
+                           Set<GenericRecord> ret = new HashSet<>();
+                           for (int i = 1; i <= topN; i++) {
+                              ret.add(copy.poll());
+                           }
+                           return ret;
+                       }
+                     },
+                     // the selector
+                     (windowedArticle, count) -> {
+                         // project on the industry field for key
+                         Windowed<String> windowedIndustry = new Windowed<>((String) windowedArticle.value().get("industry"), windowedArticle.window());
+                         // add the page into the value
+                         GenericRecord viewStats = new GenericData.Record(schema);
+                         viewStats.put("page", "pageId");
+                         viewStats.put("industry", "industryName");
+                         viewStats.put("count", count);
+                         return new KeyValue<>(windowedIndustry, viewStats);
+                     },
+                     new WindowedSerializer<>(stringSerializer),
+                     null,
+                     new CollectionSerializer<>(),
+                     new WindowedDeserializer<>(stringDeserializer),
+                     null,
+                     new CollectionDeserializer<>(),
+                     "Top100Articles");
 
         topViewCounts.to("TopNewsPerIndustry");
 
-        KafkaStreaming kstream = new KafkaStreaming(builder, config);
-        kstream.start();
+        KafkaStreams streams = new KafkaStreams(builder, streamsConfiguration);
+        streams.start();
     }
 }

--- a/streams/src/main/java/io/confluent/examples/streams/UserRegionExample.java
+++ b/streams/src/main/java/io/confluent/examples/streams/UserRegionExample.java
@@ -42,7 +42,7 @@ public class UserRegionExample {
 
     public static void main(String[] args) throws Exception {
         Properties streamsConfiguration = new Properties();
-        streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "regiongroup-example");
+        streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "user-region-example");
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         streamsConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, GenericAvroSerializer.class);

--- a/streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -13,7 +13,8 @@ import org.apache.kafka.streams._
   * Use cases include e.g. basic data sanitization, data anonymization by obfuscating sensitive data
   * fields (such as personally identifiable information aka PII).
   *
-  * Requires a version of Scala that supports Java 8 and SAM / Java lambda (e.g. Scala 2.12).
+  * Requires a version of Scala that supports Java 8 and SAM / Java lambda (e.g. Scala 2.11 with
+  * `-Xexperimental` compiler flag, or 2.12).
   */
 class MapFunctionScalaExample {
 

--- a/streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/streams/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -4,8 +4,8 @@ import java.util.Properties
 
 import io.confluent.examples.streams.utils.SystemTimestampExtractor
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, ByteArraySerializer, StringDeserializer, StringSerializer}
-import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder, KeyValue}
-import org.apache.kafka.streams.{KafkaStreaming, StreamingConfig}
+import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
+import org.apache.kafka.streams._
 
 /**
   * Demonstrates how to perform simple, state-less transformations via map functions.
@@ -68,16 +68,16 @@ class MapFunctionScalaExample {
 
     val streamingConfig = {
       val settings = new Properties
-      settings.put(StreamingConfig.JOB_ID_CONFIG, "map-function-example")
-      settings.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
-      settings.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
-      settings.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      settings.put(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer])
-      settings.put(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
-      settings.put(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, classOf[SystemTimestampExtractor])
-      new StreamingConfig(settings)
+      settings.put(StreamsConfig.JOB_ID_CONFIG, "map-function-example")
+      settings.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+      settings.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
+      settings.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
+      settings.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer])
+      settings.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
+      settings.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, classOf[SystemTimestampExtractor])
+      settings
     }
-    val stream: KafkaStreaming = new KafkaStreaming(builder, streamingConfig)
+    val stream: KafkaStreams = new KafkaStreams(builder, streamingConfig)
     stream.start()
   }
 

--- a/streams/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
+++ b/streams/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
@@ -1,0 +1,51 @@
+package io.confluent.examples.streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.streams.KeyValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utility functions to make integration testing more convenient.
+ */
+public class IntegrationTestUtils {
+
+  /**
+   * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from are
+   * already configured in the consumer).
+   * @param consumer
+   * @param maxMessages Maximum number of messages to read via the consumer.
+   * @return The values retrieved via the consumer.
+   */
+  public static <K, V> List<V> readValues(KafkaConsumer<K, V> consumer, int maxMessages) {
+    List<KeyValue<K, V>> kvs = readKeyValues(consumer, maxMessages);
+    return kvs.stream().map(kv -> kv.value).collect(Collectors.toList());
+  }
+
+  /**
+   * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from are
+   * already configured in the consumer).
+   * @param consumer
+   * @param maxMessages Maximum number of messages to read via the consumer.
+   * @return The KeyValue elements retrieved via the consumer.
+   */
+  public static <K, V> List<KeyValue<K, V>> readKeyValues(KafkaConsumer<K, V> consumer, int maxMessages) {
+    int pollIntervalMs = 100;
+    int maxTotalPollTimeMs = 2000;
+    int totalPollTimeMs = 0;
+    List<KeyValue<K, V>> consumedValues = new ArrayList<>();
+    while (totalPollTimeMs < maxTotalPollTimeMs && consumedValues.size() < maxMessages) {
+      totalPollTimeMs += pollIntervalMs;
+      ConsumerRecords<K, V> records = consumer.poll(pollIntervalMs);
+      for (ConsumerRecord<K, V> record : records) {
+        consumedValues.add(new KeyValue<>(record.key(), record.value()));
+      }
+    }
+    return consumedValues;
+  }
+
+}

--- a/streams/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
+++ b/streams/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
  */
 public class IntegrationTestUtils {
 
+  private static final int UNLIMITED_MESSAGES = -1;
+
   /**
    * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from are
    * already configured in the consumer).
@@ -24,6 +26,16 @@ public class IntegrationTestUtils {
   public static <K, V> List<V> readValues(KafkaConsumer<K, V> consumer, int maxMessages) {
     List<KeyValue<K, V>> kvs = readKeyValues(consumer, maxMessages);
     return kvs.stream().map(kv -> kv.value).collect(Collectors.toList());
+  }
+
+  /**
+   * Reading as many messages as possible via the provided consumer (the topic(s) to read from are
+   * already configured in the consumer) until a (currently hardcoded) timeout is reached.
+   * @param consumer
+   * @return The KeyValue elements retrieved via the consumer.
+   */
+  public static <K, V> List<KeyValue<K, V>> readKeyValues(KafkaConsumer<K, V> consumer) {
+    return readKeyValues(consumer, UNLIMITED_MESSAGES);
   }
 
   /**
@@ -38,7 +50,7 @@ public class IntegrationTestUtils {
     int maxTotalPollTimeMs = 2000;
     int totalPollTimeMs = 0;
     List<KeyValue<K, V>> consumedValues = new ArrayList<>();
-    while (totalPollTimeMs < maxTotalPollTimeMs && consumedValues.size() < maxMessages) {
+    while (totalPollTimeMs < maxTotalPollTimeMs && continueConsuming(consumedValues.size(), maxMessages)) {
       totalPollTimeMs += pollIntervalMs;
       ConsumerRecords<K, V> records = consumer.poll(pollIntervalMs);
       for (ConsumerRecord<K, V> record : records) {
@@ -46,6 +58,14 @@ public class IntegrationTestUtils {
       }
     }
     return consumedValues;
+  }
+
+  private static boolean continueConsuming(int messagesConsumed, int maxMessages) {
+    if (maxMessages <= 0) {
+      return true;
+    } else {
+      return messagesConsumed < maxMessages;
+    }
   }
 
 }

--- a/streams/src/test/java/io/confluent/examples/streams/MapFunctionIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/MapFunctionIntegrationTest.java
@@ -91,8 +91,8 @@ public class MapFunctionIntegrationTest {
     producerConfig.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
 
     Producer<String, String> producer = new KafkaProducer<>(producerConfig);
-    for (String line : inputValues) {
-      Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, line));
+    for (String value : inputValues) {
+      Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, value));
       f.get();
     }
     producer.flush();

--- a/streams/src/test/java/io/confluent/examples/streams/MapFunctionIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/MapFunctionIntegrationTest.java
@@ -1,0 +1,121 @@
+package io.confluent.examples.streams;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapFunctionIntegrationTest {
+
+  private static EmbeddedSingleNodeKafkaCluster cluster = null;
+  private static String inputTopic = "inputTopic";
+  private static String outputTopic = "outputTopic";
+
+  @BeforeClass
+  public static void startKafkaCluster() throws Exception {
+    cluster = new EmbeddedSingleNodeKafkaCluster();
+    cluster.createTopic(inputTopic);
+    cluster.createTopic(outputTopic);
+  }
+
+  @AfterClass
+  public static void stopKafkaCluster() throws IOException {
+    if (cluster != null) {
+      cluster.stop();
+    }
+  }
+
+  @Test
+  public void shouldUppercaseTheInput() throws Exception {
+    List<String> inputValues = Arrays.asList("hello", "world");
+    List<String> expectedValues = inputValues.stream().map(String::toUpperCase).collect(Collectors.toList());
+
+    //
+    // Step 1: Configure and start the Streams job.
+    //
+    KStreamBuilder builder = new KStreamBuilder();
+
+    // Write the input data as-is to the output topic.
+    KStream<byte[], String> input = builder.stream(inputTopic);
+
+    KStream<byte[], String> uppercased = input.mapValues(String::toUpperCase);
+    uppercased.to(outputTopic);
+
+    Properties streamsConfiguration = new Properties();
+    streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "map-function-integration-test");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+    streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+    streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+    KafkaStreams streams = new KafkaStreams(builder, streamsConfiguration);
+    streams.start();
+
+    // Wait briefly for the streaming job to be fully up and running (otherwise it might miss
+    // some or all of the input data we produce below).
+    Thread.sleep(1000);
+
+    //
+    // Step 2: Produce some input data to the input topic.
+    //
+    Properties producerConfig = new Properties();
+    producerConfig.put("bootstrap.servers", cluster.bootstrapServers());
+    producerConfig.put("acks", "all");
+    producerConfig.put("retries", 0);
+    producerConfig.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    producerConfig.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+    Producer<String, String> producer = new KafkaProducer<>(producerConfig);
+    for (String line : inputValues) {
+      Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, line));
+      f.get();
+    }
+    producer.flush();
+    producer.close();
+
+    // Give the streaming job some time to do its work.
+    Thread.sleep(1000);
+    streams.close();
+
+    //
+    // Step 3: Verify the job's output data.
+    //
+    Properties consumerConfig = new Properties();
+    consumerConfig.put("bootstrap.servers", cluster.bootstrapServers());
+    consumerConfig.put("group.id", "map-function-integration-test-standard-consumer");
+    consumerConfig.put("auto.offset.reset", "earliest");
+    consumerConfig.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+    consumerConfig.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+
+    KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig);
+    consumer.subscribe(Collections.singletonList(outputTopic));
+    List<String> actualValues = IntegrationTestUtils.readValues(consumer, inputValues.size());
+    assertThat(actualValues).isEqualTo(expectedValues);
+  }
+
+}

--- a/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -126,21 +126,8 @@ public class PassThroughIntegrationTest {
 
     KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig);
     consumer.subscribe(Collections.singletonList(outputTopic));
-    int pollIntervalMs = 100;
-    int maxTotalPollTimeMs = 2000;
-    int totalPollTimeMs = 0;
-    List<String> consumedLines = new LinkedList<>();
-    while (totalPollTimeMs < maxTotalPollTimeMs && consumedLines.size() < inputLines.size()) {
-      totalPollTimeMs += pollIntervalMs;
-      ConsumerRecords<String, String> records = consumer.poll(pollIntervalMs);
-      for (ConsumerRecord<String, String> record : records) {
-        log.debug("Received message with offset = {}, key = {}, value = {}",
-            record.offset(), record.key(), record.value());
-        consumedLines.add(record.value());
-      }
-    }
-
-    assertThat(consumedLines).isEqualTo(inputLines);
+    List<String> actualValues = IntegrationTestUtils.readValues(consumer, inputLines.size());
+    assertThat(actualValues).isEqualTo(inputLines);
   }
 
 }

--- a/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -59,7 +59,7 @@ public class PassThroughIntegrationTest {
 
   @Test
   public void shouldWriteTheInputDataAsIsToTheOutputTopic() throws Exception {
-    List<String> inputLines = Arrays.asList(
+    List<String> inputValues = Arrays.asList(
         "hello world",
         "the world is not enough",
         "the world of the stock market is coming to an end"
@@ -102,7 +102,7 @@ public class PassThroughIntegrationTest {
     producerConfig.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
 
     Producer<String, String> producer = new KafkaProducer<>(producerConfig);
-    for (String line : inputLines) {
+    for (String line : inputValues) {
       log.debug("Producing message with value '{}' to topic {}", line, inputTopic);
       Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, line));
       f.get();
@@ -126,8 +126,8 @@ public class PassThroughIntegrationTest {
 
     KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerConfig);
     consumer.subscribe(Collections.singletonList(outputTopic));
-    List<String> actualValues = IntegrationTestUtils.readValues(consumer, inputLines.size());
-    assertThat(actualValues).isEqualTo(inputLines);
+    List<String> actualValues = IntegrationTestUtils.readValues(consumer, inputValues.size());
+    assertThat(actualValues).isEqualTo(inputValues);
   }
 
 }

--- a/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -1,7 +1,5 @@
 package io.confluent.examples.streams;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -15,13 +13,10 @@ import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Future;
@@ -36,8 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * a new output topic.
  */
 public class PassThroughIntegrationTest {
-
-  private static final Logger log = LoggerFactory.getLogger(PassThroughIntegrationTest.class);
 
   private static EmbeddedSingleNodeKafkaCluster cluster = null;
   private static String inputTopic = "inputTopic";
@@ -102,9 +95,8 @@ public class PassThroughIntegrationTest {
     producerConfig.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
 
     Producer<String, String> producer = new KafkaProducer<>(producerConfig);
-    for (String line : inputValues) {
-      log.debug("Producing message with value '{}' to topic {}", line, inputTopic);
-      Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, line));
+    for (String value : inputValues) {
+      Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, value));
       f.get();
     }
     producer.flush();

--- a/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -74,7 +74,7 @@ public class PassThroughIntegrationTest {
     builder.stream(inputTopic).to(outputTopic);
 
     Properties streamingConfiguration = new Properties();
-    streamingConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "noop-test-streams");
+    streamingConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "pass-through-integration-test");
     streamingConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
     streamingConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     streamingConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -119,7 +119,7 @@ public class PassThroughIntegrationTest {
     //
     Properties consumerConfig = new Properties();
     consumerConfig.put("bootstrap.servers", cluster.bootstrapServers());
-    consumerConfig.put("group.id", "noop-test-standard-consumer");
+    consumerConfig.put("group.id", "pass-through-integration-test-standard-consumer");
     consumerConfig.put("auto.offset.reset", "earliest");
     consumerConfig.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
     consumerConfig.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");

--- a/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -9,8 +9,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreaming;
-import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -74,18 +74,18 @@ public class PassThroughIntegrationTest {
     builder.stream(inputTopic).to(outputTopic);
 
     Properties streamingConfiguration = new Properties();
-    streamingConfiguration.put(StreamingConfig.JOB_ID_CONFIG, "noop-test-streams");
-    streamingConfiguration.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-    streamingConfiguration.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    streamingConfiguration.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    streamingConfiguration.put(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    streamingConfiguration.put(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    streamingConfiguration.put(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, SystemTimestampExtractor.class);
+    streamingConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "noop-test-streams");
+    streamingConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+    streamingConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    streamingConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    streamingConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    streamingConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    streamingConfiguration.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, SystemTimestampExtractor.class);
     // You can also define consumer configuration settings.
     //streamingConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
-    KafkaStreaming kafkaStreaming = new KafkaStreaming(builder, new StreamingConfig(streamingConfiguration));
-    kafkaStreaming.start();
+    KafkaStreams streams = new KafkaStreams(builder, streamingConfiguration);
+    streams.start();
 
     // Wait briefly for the streaming job to be fully up and running (otherwise it might miss
     // some or all of the input data we produce below).
@@ -112,7 +112,7 @@ public class PassThroughIntegrationTest {
 
     // Give the streaming job some time to do its work.
     Thread.sleep(1000);
-    kafkaStreaming.close();
+    streams.close();
 
     //
     // Step 3: Verify the job's output data.

--- a/streams/src/test/java/io/confluent/examples/streams/WordCountIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/WordCountIntegrationTest.java
@@ -24,7 +24,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -150,10 +153,15 @@ public class WordCountIntegrationTest {
     assertThat(actualValues).containsExactlyElementsOf(expectedValues);
   }
 
-  private static void purgeLocalStreamsState(Properties streamingConfiguration) {
-    String value = streamingConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
-    if (value != null && value.startsWith("/tmp")) {
-      CoreUtils.rm(value);
+  private static void purgeLocalStreamsState(Properties streamingConfiguration) throws IOException {
+    String path = streamingConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
+    if (path != null) {
+      File node = Paths.get(path).normalize().toFile();
+      // Only purge state when it's under /tmp.  This is a safety net to prevent accidentally
+      // deleting important local directory trees.
+      if (node.getAbsolutePath().startsWith("/tmp")) {
+        CoreUtils.rm(node);
+      }
     }
   }
 

--- a/streams/src/test/java/io/confluent/examples/streams/WordCountIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/WordCountIntegrationTest.java
@@ -1,0 +1,160 @@
+package io.confluent.examples.streams;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.WindowedSerializer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import kafka.utils.CoreUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WordCountIntegrationTest {
+
+  private static EmbeddedSingleNodeKafkaCluster cluster = null;
+  private static String inputTopic = "inputTopic";
+  private static String outputTopic = "outputTopic";
+
+  @BeforeClass
+  public static void startKafkaCluster() throws Exception {
+    cluster = new EmbeddedSingleNodeKafkaCluster();
+    cluster.createTopic(inputTopic);
+    cluster.createTopic(outputTopic);
+  }
+
+  @AfterClass
+  public static void stopKafkaCluster() throws IOException {
+    if (cluster != null) {
+      cluster.stop();
+    }
+  }
+
+  @Test
+  public void shouldCountWords() throws Exception {
+    List<String> inputValues = Arrays.asList("hello", "world", "world", "hello world");
+    List<KeyValue<String, Long>> expectedValues = Arrays.asList(
+        new KeyValue<>("hello", 1L),
+        new KeyValue<>("world", 1L),
+        new KeyValue<>("world", 2L),
+        new KeyValue<>("hello", 2L),
+        new KeyValue<>("world", 3L)
+    );
+
+    //
+    // Step 1: Configure and start the Streams job.
+    //
+    final Serializer<String> stringSerializer = new StringSerializer();
+    final Deserializer<String> stringDeserializer = new StringDeserializer();
+    final Serializer<Long> longSerializer = new LongSerializer();
+    final Deserializer<Long> longDeserializer = new LongDeserializer();
+
+    Properties streamsConfiguration = new Properties();
+    streamsConfiguration.put(StreamsConfig.JOB_ID_CONFIG, "wordcount-integration-test");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kafka-streams");
+
+    // Remove any state from previous test runs
+    purgeLocalStreamsState(streamsConfiguration);
+
+    KStreamBuilder builder = new KStreamBuilder();
+
+    KStream<String, String> source = builder.stream(inputTopic);
+
+    KStream<String, Long> counts = source
+        .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
+        .map((key, value) -> new KeyValue<>(value, value))
+        .countByKey(UnlimitedWindows.of("Counts").startOn(0L),
+            stringSerializer, longSerializer, stringDeserializer, longDeserializer)
+        .toStream()
+        .map((windowedKey, count) -> new KeyValue<>(windowedKey.value(), count));
+
+    counts.to(outputTopic, stringSerializer, longSerializer);
+
+    KafkaStreams streams = new KafkaStreams(builder, streamsConfiguration);
+    streams.start();
+
+    // Wait briefly for the streaming job to be fully up and running (otherwise it might miss
+    // some or all of the input data we produce below).
+    Thread.sleep(1000);
+
+    //
+    // Step 2: Produce some input data to the input topic.
+    //
+    Properties producerConfig = new Properties();
+    producerConfig.put("bootstrap.servers", cluster.bootstrapServers());
+    producerConfig.put("acks", "all");
+    producerConfig.put("retries", 0);
+    producerConfig.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    producerConfig.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+
+    Producer<String, String> producer = new KafkaProducer<>(producerConfig);
+    for (String value : inputValues) {
+      Future<RecordMetadata> f = producer.send(new ProducerRecord<>(inputTopic, value));
+      f.get();
+    }
+    producer.flush();
+    producer.close();
+
+    // Give the streaming job some time to do its work.
+    Thread.sleep(1000);
+    streams.close();
+
+    //
+    // Step 3: Verify the job's output data.
+    //
+    Properties consumerConfig = new Properties();
+    consumerConfig.put("bootstrap.servers", cluster.bootstrapServers());
+    consumerConfig.put("group.id", "wordcount-integration-test-standard-consumer");
+    consumerConfig.put("auto.offset.reset", "earliest");
+    consumerConfig.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+    consumerConfig.put("value.deserializer", "org.apache.kafka.common.serialization.LongDeserializer");
+
+    KafkaConsumer<String, Long> consumer = new KafkaConsumer<>(consumerConfig);
+    consumer.subscribe(Collections.singletonList(outputTopic));
+    List<KeyValue<String, Long>> actualValues = IntegrationTestUtils.readKeyValues(consumer);
+
+    // Note: This assert statement will work once we have merged the PR for equality semantics of
+    //       `KeyValue`.  See https://github.com/apache/kafka/pull/872.
+    assertThat(actualValues).containsExactlyElementsOf(expectedValues);
+  }
+
+  private static void purgeLocalStreamsState(Properties streamingConfiguration) {
+    String value = streamingConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
+    if (value != null && value.startsWith("/tmp")) {
+      CoreUtils.rm(value);
+    }
+  }
+
+}

--- a/streams/src/test/java/io/confluent/examples/streams/WordCountIntegrationTest.java
+++ b/streams/src/test/java/io/confluent/examples/streams/WordCountIntegrationTest.java
@@ -98,6 +98,8 @@ public class WordCountIntegrationTest {
     KStream<String, Long> counts = source
         .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
         .map((key, value) -> new KeyValue<>(value, value))
+        // The following countByKey().toStream().map() chain can be simplified to just
+        // countByKey() once https://github.com/apache/kafka/pull/870 is merged.
         .countByKey(UnlimitedWindows.of("Counts").startOn(0L),
             stringSerializer, longSerializer, stringDeserializer, longDeserializer)
         .toStream()


### PR DESCRIPTION
I updated the examples so they compile again, and I also added another end-to-end integration test.

@ymatsuda, @guozhangwang: Please review, I'm really not sure whether the code is correct beyond being able to tell that the code compiles.  For example, the current (compile-ready) code of TopArticlesExample (see `FIXME`) seems to be broken because the add and the remove aggregators do not share state (which they should however, as far as I understand) -- this was not a problem in the previous Streams API when there was a single aggregator instance that had both `add` and `remove` operations, but in the new API there are two different aggregator instances (one for `add`, one for `remove`).
