### PR TITLE
Fix Streams examples

### DIFF
--- a/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
@@ -40,7 +40,6 @@ import org.apache.kafka.streams.kstream.internals.WindowedDeserializer;
 import org.apache.kafka.streams.kstream.internals.WindowedSerializer;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.PriorityQueue;
 import java.util.Properties;

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/TopArticlesLambdaExample.java
@@ -48,6 +48,11 @@ import java.util.Properties;
  * Create a data feed of the top 100 news articles per industry, ranked by click-through-rate
  * (assuming this is for the past week).
  *
+ * Note: The generic Avro binding is used for serialization/deserialization.  This means the
+ * appropriate Avro schema files must be provided for each of the "intermediate" Avro classes, i.e.
+ * whenever new types of Avro objects (in the form of GenericRecord) are being passed between
+ * processing steps.
+ *
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class TopArticlesLambdaExample {

--- a/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
+++ b/kafka-streams/src/main/java/io/confluent/examples/streams/UserRegionLambdaExample.java
@@ -64,7 +64,7 @@ public class UserRegionLambdaExample {
             // filter out incomplete profiles with less than 200 characters
             .filter((userId, record) -> ((String) record.get("experience")).getBytes().length > 200)
             // count by region, we can set null to all serdes to use defaults
-            .count((userId, record) ->  new KeyValue<>((String) record.get("region"), record),
+            .count((userId, record) ->  (String) record.get("region"),
                 null, null, longSerializer, null, null, longDeserializer, "CountsByRegion")
             // filter out regions with less than 10M users
             .filter((regionName, count) -> count > 10 * 1000 * 1000);

--- a/kafka-streams/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
+++ b/kafka-streams/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
@@ -74,7 +74,6 @@ public class MapFunctionLambdaIntegrationTest {
     streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
     streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    streamsConfiguration.put(StreamsConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     // Write the input data as-is to the output topic.
     KStream<byte[], String> input = builder.stream(inputTopic);

--- a/kafka-streams/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
+++ b/kafka-streams/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
@@ -80,8 +80,6 @@ public class MapFunctionLambdaIntegrationTest {
 
     KStream<byte[], String> uppercased = input.mapValues(String::toUpperCase);
 
-    // String::toUpperCase
-
     uppercased.to(outputTopic);
 
     KafkaStreams streams = new KafkaStreams(builder, streamsConfiguration);

--- a/kafka-streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/kafka-streams/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -72,7 +72,6 @@ public class PassThroughIntegrationTest {
     streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    streamsConfiguration.put(StreamsConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     // Write the input data as-is to the output topic.
     builder.stream(inputTopic).to(outputTopic);

--- a/kafka-streams/src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java
+++ b/kafka-streams/src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java
@@ -89,6 +89,12 @@ public class WordCountLambdaIntegrationTest {
     streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     streamsConfiguration.put(StreamsConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    // Explicitly place the state directory under /tmp so that we can remove it via
+    // `purgeLocalStreamsState` below.  Once Streams is updated to expose the effective
+    // StreamsConfig configuration (so we can retrieve whatever state directory Streams came up
+    // with automatically) we don't need to set this anymore and can update `purgeLocalStreamsState`
+    // accordingly.
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kafka-streams");
 
     // Remove any state from previous test runs
     purgeLocalStreamsState(streamsConfiguration);

--- a/kafka-streams/src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java
+++ b/kafka-streams/src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java
@@ -88,7 +88,6 @@ public class WordCountLambdaIntegrationTest {
     streamsConfiguration.put(StreamsConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     streamsConfiguration.put(StreamsConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     streamsConfiguration.put(StreamsConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    streamsConfiguration.put(StreamsConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Explicitly place the state directory under /tmp so that we can remove it via
     // `purgeLocalStreamsState` below.  Once Streams is updated to expose the effective
     // StreamsConfig configuration (so we can retrieve whatever state directory Streams came up


### PR DESCRIPTION
The latest commit https://github.com/guozhangwang/examples/commit/e8cfc2400d4c10b043f42f210fc3cd2148b12109 broke the Streams examples.  This commit reverts most of the changes to make them work again.
